### PR TITLE
Fix for "redis.geoadd parameters were changed".

### DIFF
--- a/mapmatching/data.py
+++ b/mapmatching/data.py
@@ -35,7 +35,7 @@ def load_to_redis(data, redis):
         if etype == 'node':
             # load to GEOHASH with ID
             redis.geoadd(
-                'base:nodehash', element['lon'], element['lat'], eid
+                'base:nodehash', (element['lon'], element['lat'], eid)
             )
             # add to node count
             redis.pfadd('base:node:count', eid)


### PR DESCRIPTION
Dear Abraham Toriz Cruz,

I found issue about redis.geoadd method.
Originally, redis.geoadd has 4 parameters.
But new parameters have 1 name and 1 tuple.

I fixed only 1 line.

Please check it .

Best Regards,

Daizyu